### PR TITLE
Update Layerfile test suite 10

### DIFF
--- a/Layerfile
+++ b/Layerfile
@@ -11,9 +11,6 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
 # Check Node and npm versions
 RUN node -v && npm -v
 
-# Install Jest and Puppeteer for JavaScript testing
-RUN npm install --global jest puppeteer
-
 # Copy the repository contents to the VM
 COPY . .
 


### PR DESCRIPTION
removal of install  jest and puppeteer from the layer file to better understand the unit test. Jest and puppeteer were failing to install in the VM.